### PR TITLE
テストを考慮して、現在日時を生成するCurrentFactoryを追加

### DIFF
--- a/app/cores/datetime/CurrentFactory.scala
+++ b/app/cores/datetime/CurrentFactory.scala
@@ -1,0 +1,70 @@
+package cores.datetime
+
+import java.time._
+
+object CurrentFactory {
+  /**
+    * 現在の時点の日時へのアクセスを提供するクロック
+    *
+    * テストクラス一個だとvolatileなしでも問題ないが、複数テスト走らせるとvolatileなしだとテストこける可能性がある（過去の経験上）
+    * joda-timeを参照したトコロ、同様の機構にvolatileをつけて実装しているので、同じように実装している
+    * 参考：https://github.com/JodaOrg/joda-time/blob/master/src/main/java/org/joda/time/DateTimeUtils.java
+    */
+  @volatile
+  private var clock: Clock = Clock.systemDefaultZone()
+
+  /**
+    * 現在日時を生成する
+    *
+    * @return 現在日時
+    */
+  def factoryLocalDateTime(): LocalDateTime = {
+    LocalDateTime.ofInstant(clock.instant(), ZoneId.systemDefault())
+  }
+
+  /**
+    * 指定したタイムゾーンの現在日時を生成する
+    *
+    * @param zoneId タイムゾーンID
+    * @return 指定したタイムゾーンの現在日時
+    */
+  def factoryZonedDateTime(zoneId: ZoneId): ZonedDateTime = {
+    ZonedDateTime.ofInstant(clock.instant(), zoneId)
+  }
+
+  /**
+    * 現在時刻を生成する
+    *
+    * @return 現在時刻
+    */
+  def factoryLocalTime(): LocalTime = {
+    LocalTime.from(factoryLocalDateTime())
+  }
+
+  /**
+    * 現在日付を生成する
+    *
+    * @return 現在日付
+    */
+  def factoryLocalDate(): LocalDate = {
+    LocalDate.from(factoryLocalDateTime())
+  }
+
+  /**
+    * テスト用のクロックをセット
+    *
+    * テストコードからのみ呼び出されることを想定している。
+    */
+  def setForTest(clock: Clock): Unit = {
+    this.clock = clock
+  }
+
+  /**
+    * システムクロックにリセット
+    *
+    * テストコードからのみ呼び出されることを想定している。
+    */
+  def resetForTest(): Unit = {
+    clock = Clock.systemDefaultZone()
+  }
+}

--- a/test/cores/datetime/CurrentFactorySpec.scala
+++ b/test/cores/datetime/CurrentFactorySpec.scala
@@ -1,0 +1,84 @@
+package cores.datetime
+
+import java.time._
+
+import org.scalatest.{BeforeAndAfterEach, Suite}
+import org.scalatestplus.play.PlaySpec
+
+class CurrentFactorySpec extends PlaySpec with FixedDateTime {
+
+  override def createZonedDateTime(): ZonedDateTime = { defaultZonedDateTime() }
+
+  "factoryLocalDateTime" should {
+    "success" in {
+      val actual = CurrentFactory.factoryLocalDateTime()
+
+      actual.toString mustBe "2016-12-31T23:59:59"
+    }
+  }
+
+  "factoryZonedDateTime" should {
+    "success" in {
+      val actual = CurrentFactory.factoryZonedDateTime(ZoneId.of("Australia/Darwin"))
+
+      actual.toString mustBe "2017-01-01T00:29:59+09:30[Australia/Darwin]"
+    }
+  }
+
+  "factoryLocalTime" should {
+    "success" in {
+      val actual = CurrentFactory.factoryLocalTime()
+
+      actual.toString mustBe "23:59:59"
+    }
+  }
+
+  "factoryLocalDate" should {
+    "success" in {
+      val actual = CurrentFactory.factoryLocalDate()
+
+      actual.toString mustBe "2016-12-31"
+    }
+  }
+}
+
+trait FixedDateTime extends BeforeAndAfterEach {
+  this: Suite =>
+
+  /**
+    * このメソッドをオーバーライドすると、任意の時間に固定できる
+    *
+    * @return 固定した現在日時
+    */
+  def createZonedDateTime(): ZonedDateTime
+
+  /**
+    * デフォルトの固定日時
+    */
+  def defaultZonedDateTime(): ZonedDateTime = {
+    ZonedDateTime.of(DEFAULT_LOCAL_DATE_TIME, ZoneId.systemDefault)
+  }
+  private val DEFAULT_LOCAL_DATE_TIME = LocalDateTime.of(2016, 12, 31, 23, 59, 59)
+
+  /**
+    * テストケースごとに現在日時を固定する
+    */
+  override def beforeEach(): Unit = {
+    val instant = createZonedDateTime().toInstant
+    val fixedClock = Clock.fixed(instant, ZoneId.systemDefault)
+    CurrentFactory.setForTest(fixedClock)
+
+    super.beforeEach() // To be stackable, must call super.beforeEach
+  }
+
+  /**
+    * テストケースごとに現在日時をリセットする
+    */
+  override def afterEach(): Unit = {
+    try {
+      super.afterEach() // To be stackable, must call super.afterEach
+    } finally {
+      CurrentFactory.resetForTest()
+    }
+  }
+}


### PR DESCRIPTION
DIでやる方法もあるが、現在日時の生成が、DIできるオブジェクトに限定されるため、独自の仕組みを用意。

* DI前提の場合、下記を参照する
  * http://qiita.com/harry0000/items/367b4c8f9b28b80898c6