### PR TITLE
プロダクトコードのWartremoverの警告を駆逐

### DIFF
--- a/app/Filters.scala
+++ b/app/Filters.scala
@@ -27,7 +27,7 @@ class Filters @Inject() (
     // Use the example filter if we're running development mode. If
     // we're running in production or test mode then don't use any
     // filters at all.
-    if (env.mode == Mode.Dev) Seq(exampleFilter) else Seq.empty
+    if (env.mode == Mode.Dev) Seq(exampleFilter) else Seq.empty[Filter]
   }
 
 }

--- a/app/Filters.scala
+++ b/app/Filters.scala
@@ -23,7 +23,7 @@ class Filters @Inject() (
   env: Environment,
   exampleFilter: ExampleFilter) extends HttpFilters {
 
-  override val filters = {
+  override val filters: Seq[Filter] = {
     // Use the example filter if we're running development mode. If
     // we're running in production or test mode then don't use any
     // filters at all.

--- a/app/Module.scala
+++ b/app/Module.scala
@@ -19,6 +19,20 @@ import services.{ApplicationTimer, AtomicCounter, Counter}
  * adding `play.modules.enabled` settings to the `application.conf`
  * configuration file.
  */
+
+/**
+  * NonUnitStatements を抑制している理由
+  *
+  * オーバーライドしている configure メソッドは AbstractModule クラスでは void で定義されている。
+  * よって、返り値を Unit にしているのは正しい。
+  *
+  * 一方で Scala の言語仕様上、メソッドの最終行の結果が return される挙動をする。
+  * そのため、バインドに関わるメソッド（例えば to メソッド）の返り値が void ではない場合に
+  * 「Statements must return Unit」という警告が出てしまう。
+  *
+  * 以上のことを勘案した上で、ここでの返り値は、重要な関心事ではないと判断し、警告を抑制することとした。
+  */
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class Module extends AbstractModule {
 
   override def configure(): Unit = {

--- a/app/controllers/AsyncController.scala
+++ b/app/controllers/AsyncController.scala
@@ -18,6 +18,7 @@ import scala.concurrent.duration._
  * asynchronous code.
  */
 @Singleton
+@SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.NonUnitStatements"))
 class AsyncController @Inject() (actorSystem: ActorSystem)(implicit exec: ExecutionContext) extends Controller {
 
   /**

--- a/app/controllers/article/ArticleController.scala
+++ b/app/controllers/article/ArticleController.scala
@@ -19,10 +19,9 @@ class ArticleController @Inject()(articleService: ArticleService) extends Contro
           println("hoge: " + articleEntity.title + " : " + articleEntity.url) // scalastyle:ignore
         }
 
-        if (articleEntities.nonEmpty) {
-          Ok(Json.toJson(articleEntities.head.title))
-        }else{
-          Ok(Json.toJson("empty"))
+        articleEntities.headOption match {
+          case Some(articleEntity) => Ok(Json.toJson(articleEntity.title))
+          case None  => Ok(Json.toJson("empty"))
         }
       }
     }

--- a/app/cores/datetime/CurrentFactory.scala
+++ b/app/cores/datetime/CurrentFactory.scala
@@ -9,7 +9,10 @@ object CurrentFactory {
     * テストクラス一個だとvolatileなしでも問題ないが、複数テスト走らせるとvolatileなしだとテストこける可能性がある（過去の経験上）
     * joda-timeを参照したトコロ、同様の機構にvolatileをつけて実装しているので、同じように実装している
     * 参考：https://github.com/JodaOrg/joda-time/blob/master/src/main/java/org/joda/time/DateTimeUtils.java
+    *
+    * なお、Wartremoverにvarを使うなと怒られるが、ここではvarにしないといけない箇所なので、警告は抑制する。
     */
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
   @volatile
   private var clock: Clock = Clock.systemDefaultZone()
 

--- a/app/cores/datetime/DateTimeProvider.scala
+++ b/app/cores/datetime/DateTimeProvider.scala
@@ -58,11 +58,23 @@ object DateTimeProvider {
     * テスト用のクロックを使用
     *
     * テストコードからのみ呼び出されることを想定している。
+    * システムのデフォルトタイムゾーンを使用する。
+    *
+    * @param localDateTime 固定する現在日時
+    */
+  def useFixedClockForTest(localDateTime: LocalDateTime): Unit = {
+    useFixedClockForTest(localDateTime, DEFAULT_ZONE_ID)
+  }
+
+  /**
+    * テスト用のクロックを使用
+    *
+    * テストコードからのみ呼び出されることを想定している。
     *
     * @param localDateTime 固定する現在日時
     * @param zoneId タイムゾーンID（省略時はシステムのデフォルトタイムゾーンを使用）
     */
-  def useFixedClockForTest(localDateTime: LocalDateTime, zoneId: ZoneId = DEFAULT_ZONE_ID): Unit = {
+  def useFixedClockForTest(localDateTime: LocalDateTime, zoneId: ZoneId): Unit = {
     clock = Clock.fixed(ZonedDateTime.of(localDateTime, zoneId).toInstant, zoneId)
   }
 

--- a/app/cores/datetime/DateTimeProvider.scala
+++ b/app/cores/datetime/DateTimeProvider.scala
@@ -24,7 +24,10 @@ object DateTimeProvider {
     * テストクラス一個だとvolatileなしでも問題ないが、複数テスト走らせるとvolatileなしだとテストこける可能性がある（過去の経験上）
     * joda-timeを参照したトコロ、同様の機構にvolatileをつけて実装しているので、同じように実装している
     * 参考：https://github.com/JodaOrg/joda-time/blob/master/src/main/java/org/joda/time/DateTimeUtils.java
+    *
+    * なお、Wartremoverにvarを使うなと怒られるが、ここではvarにしないといけない箇所なので、警告は抑制する。
     */
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
   @volatile
   private var clock: Clock = Clock.systemDefaultZone()
 

--- a/app/domains/article/ArticleEntity.scala
+++ b/app/domains/article/ArticleEntity.scala
@@ -1,5 +1,6 @@
 package domains.article
 
+@SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
 case class ArticleEntity(
                           id: Option[Int] = None,
                           title: String,

--- a/app/domains/article/ArticleEntity.scala
+++ b/app/domains/article/ArticleEntity.scala
@@ -1,8 +1,8 @@
 package domains.article
 
 @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-case class ArticleEntity(
-                          id: Option[Int] = None,
-                          title: String,
-                          url: String
-                        )
+final case class ArticleEntity(
+                                id: Option[Int] = None,
+                                title: String,
+                                url: String
+                              )

--- a/app/domains/crawler/HatenaBookmarkParser.scala
+++ b/app/domains/crawler/HatenaBookmarkParser.scala
@@ -3,5 +3,5 @@ package domains.crawler
 import domains.article.ArticleEntity
 
 trait HatenaBookmarkParser {
-  def parse(rss: String): List[ArticleEntity]
+  def parse(rss: String): Seq[ArticleEntity]
 }

--- a/app/filters/ExampleFilter.scala
+++ b/app/filters/ExampleFilter.scala
@@ -16,6 +16,7 @@ import scala.concurrent.{ExecutionContext, Future}
  * It is used below by the `map` method.
  */
 @Singleton
+@SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
 class ExampleFilter @Inject()(
     implicit override val mat: Materializer,
     exec: ExecutionContext) extends Filter {

--- a/app/infrastructures/article/ArticleRepositoryImpl.scala
+++ b/app/infrastructures/article/ArticleRepositoryImpl.scala
@@ -21,6 +21,7 @@ class ArticleRepositoryImpl @Inject()(protected val dbConfigProvider: DatabaseCo
   override def insert(articleEntity: ArticleEntity): Future[Unit] = db.run(Articles += articleEntity).map { _ => () }
 
   // scalastyle:off
+  @SuppressWarnings(Array("org.wartremover.warts.Nothing"))
   private class ArticlesTable(tag: Tag) extends Table[ArticleEntity](tag, "articles") {
     def id = column[Int]("id", O.PrimaryKey)
     def title = column[String]("title")

--- a/app/infrastructures/crawler/HatenaBookmarkParserImpl.scala
+++ b/app/infrastructures/crawler/HatenaBookmarkParserImpl.scala
@@ -5,22 +5,17 @@ import javax.inject.Singleton
 import domains.article.ArticleEntity
 import domains.crawler.HatenaBookmarkParser
 
-import scala.collection.mutable.ListBuffer
 import scala.xml.{NodeSeq, XML}
 
 @Singleton
 class HatenaBookmarkParserImpl extends HatenaBookmarkParser {
 
-  override def parse(rss: String): List[ArticleEntity] = {
-    var result = ListBuffer.empty[ArticleEntity]
-    for (item <- items(rss)) {
+  override def parse(rss: String): Seq[ArticleEntity] = {
+    items(rss).map(item => {
       val title = (item \ "title").text
       val url = (item \ "link").text
-
-      val articleEntity = ArticleEntity(None, title, url)
-      result += articleEntity
-    }
-    result.toList
+      ArticleEntity(None, title, url)
+    })
   }
 
   private def items(string: String): NodeSeq = {

--- a/app/services/crawler/HatenaBookmarkService.scala
+++ b/app/services/crawler/HatenaBookmarkService.scala
@@ -7,7 +7,7 @@ import domains.article.{ArticleEntity, ArticleRepository}
 import domains.crawler.{HatenaBookmarkApi, HatenaBookmarkParser}
 
 trait HatenaBookmarkService {
-  def crawl(): List[ArticleEntity]
+  def crawl(): Seq[ArticleEntity]
 }
 
 @Singleton
@@ -16,7 +16,7 @@ class HatenaBookmarkServiceImpl @Inject()(
                                            hatenaBookmarkParser: HatenaBookmarkParser,
                                            articleRepository: ArticleRepository) extends HatenaBookmarkService {
 
-  override def crawl(): List[ArticleEntity] = {
+  override def crawl(): Seq[ArticleEntity] = {
     val response = hatenaBookmarkApi.request()
     val articleEntities = hatenaBookmarkParser.parse(response.apply())
     for (articleEntity <- articleEntities){


### PR DESCRIPTION
### Before

```
[warn] /Users/owner/github/scala-ddd/app/Filters.scala:30: [wartremover:Equals] == is disabled - use === or equivalent instead
[warn]     if (env.mode == Mode.Dev) Seq(exampleFilter) else Seq.empty
[warn]                  ^
[warn] /Users/owner/github/scala-ddd/app/Filters.scala:30: [wartremover:Nothing] Inferred type containing Nothing
[warn]     if (env.mode == Mode.Dev) Seq(exampleFilter) else Seq.empty
[warn]                                                           ^
[warn] /Users/owner/github/scala-ddd/app/Filters.scala:26: [wartremover:PublicInference] Public member must have an explicit type ascription
[warn]   override val filters = {
[warn]                ^
[warn] /Users/owner/github/scala-ddd/app/Module.scala:31: [wartremover:NonUnitStatements] Statements must return Unit
[warn]     bind(classOf[Counter]).to(classOf[AtomicCounter])
[warn]                              ^
[warn] /Users/owner/github/scala-ddd/app/Module.scala:34: [wartremover:NonUnitStatements] Statements must return Unit
[warn]     configureServices()
[warn]                      ^
[warn] /Users/owner/github/scala-ddd/app/Module.scala:35: [wartremover:NonUnitStatements] Statements must return Unit
[warn]     configureInfrastructures()
[warn]                             ^
[warn] /Users/owner/github/scala-ddd/app/Module.scala:39: [wartremover:NonUnitStatements] Statements must return Unit
[warn]     bind(classOf[HatenaBookmarkService]).to(classOf[HatenaBookmarkServiceImpl])
[warn]                                            ^
[warn] /Users/owner/github/scala-ddd/app/Module.scala:44: [wartremover:NonUnitStatements] Statements must return Unit
[warn]     bind(classOf[ArticleRepository]).to(classOf[ArticleRepositoryImpl])
[warn]                                        ^
[warn] /Users/owner/github/scala-ddd/app/Module.scala:45: [wartremover:NonUnitStatements] Statements must return Unit
[warn]     bind(classOf[HatenaBookmarkApi]).to(classOf[HatenaBookmarkApiImpl])
[warn]                                        ^
[warn] /Users/owner/github/scala-ddd/app/controllers/AsyncController.scala:21: [wartremover:ImplicitParameter] Implicit parameters are disabled
[warn] class AsyncController @Inject() (actorSystem: ActorSystem)(implicit exec: ExecutionContext) extends Controller {
[warn]                                                                                                     ^
[warn] /Users/owner/github/scala-ddd/app/controllers/AsyncController.scala:37: [wartremover:NonUnitStatements] Statements must return Unit
[warn]     actorSystem.scheduler.scheduleOnce(delayTime) { promise.success("Hi!") }
[warn]                                                   ^
[warn] /Users/owner/github/scala-ddd/app/controllers/AsyncController.scala:37: [wartremover:NonUnitStatements] Statements must return Unit
[warn]     actorSystem.scheduler.scheduleOnce(delayTime) { promise.success("Hi!") }
[warn]                                                                    ^
[warn] /Users/owner/github/scala-ddd/app/controllers/article/ArticleController.scala:23: [wartremover:TraversableOps] head is disabled - use headOption instead
[warn]           Ok(Json.toJson(articleEntities.head.title))
[warn]                                          ^
[warn] /Users/owner/github/scala-ddd/app/cores/datetime/CurrentFactory.scala:14: [wartremover:Var] var is disabled
[warn]   private var clock: Clock = Clock.systemDefaultZone()
[warn]               ^
[warn] /Users/owner/github/scala-ddd/app/cores/datetime/DateTimeProvider.scala:62: [wartremover:DefaultArguments] Function has default arguments
[warn]   def useFixedClockForTest(localDateTime: LocalDateTime, zoneId: ZoneId = DEFAULT_ZONE_ID): Unit = {
[warn]                                                          ^
[warn] /Users/owner/github/scala-ddd/app/cores/datetime/DateTimeProvider.scala:29: [wartremover:Var] var is disabled
[warn]   private var clock: Clock = Clock.systemDefaultZone()
[warn]               ^
[warn] /Users/owner/github/scala-ddd/app/domains/article/ArticleEntity.scala:4: [wartremover:DefaultArguments] Function has default arguments
[warn]                           id: Option[Int] = None,
[warn]                           ^
[warn] /Users/owner/github/scala-ddd/app/domains/article/ArticleEntity.scala:3: [wartremover:FinalCaseClass] case classes must be final
[warn] case class ArticleEntity(
[warn]            ^
[warn] /Users/owner/github/scala-ddd/app/filters/ExampleFilter.scala:21: [wartremover:ImplicitParameter] Implicit parameters are disabled
[warn]     exec: ExecutionContext) extends Filter {
[warn]                                     ^
[warn] /Users/owner/github/scala-ddd/app/infrastructures/article/ArticleRepositoryImpl.scala:29: [wartremover:Nothing] Inferred type containing Nothing
[warn]     def * = (id.?, title, url) <> (ArticleEntity.tupled, ArticleEntity.unapply _)
[warn]                                ^
[warn] /Users/owner/github/scala-ddd/app/infrastructures/crawler/HatenaBookmarkParserImpl.scala:15: [wartremover:MutableDataStructures] scala.collection.mutable package is disabled
[warn]     var result = ListBuffer.empty[ArticleEntity]
[warn]                  ^
[warn] /Users/owner/github/scala-ddd/app/infrastructures/crawler/HatenaBookmarkParserImpl.scala:15: [wartremover:Var] var is disabled
[warn]     var result = ListBuffer.empty[ArticleEntity]
[warn]         ^
[warn] 22 warnings found
```

### After

```
[warn] /var/opt/app/app/Filters.scala:30: [wartremover:Equals] == is disabled - use === or equivalent instead
[warn]     if (env.mode == Mode.Dev) Seq(exampleFilter) else Seq.empty[Filter]
[warn]                  ^
[warn] one warning found
```