### PR TITLE
テストコードのWartremoverの警告を駆逐

### DIFF
--- a/test/ApplicationSpec.scala
+++ b/test/ApplicationSpec.scala
@@ -7,6 +7,7 @@ import play.api.test.Helpers._
  * You can mock out a whole application including requests, plugins etc.
  * For more information, consult the wiki.
  */
+@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
 class ApplicationSpec extends PlaySpec with OneAppPerTest {
 
   "Routes" should {

--- a/test/IntegrationSpec.scala
+++ b/test/IntegrationSpec.scala
@@ -12,7 +12,7 @@ class IntegrationSpec extends PlaySpec with OneServerPerTest with OneBrowserPerT
 
     "work from within a browser" in {
 
-      go to ("http://localhost:" + port)
+      go to ("http://localhost:" + port.toString)
 
       pageSource must include ("Your new application is ready.")
     }

--- a/test/base/scalatest/DatabaseSpec.scala
+++ b/test/base/scalatest/DatabaseSpec.scala
@@ -59,5 +59,5 @@ trait DatabaseSpec extends PlaySpec with OneAppPerSuite with BeforeAndAfterEach 
   /**
     * ここから下は、Google Guiceのinjectionをテスト内で実行するためのおまじない
     */
-  lazy val databaseApi = app.injector.instanceOf[DBApi] //here is the important line
+  private lazy val databaseApi: DBApi = app.injector.instanceOf[DBApi] //here is the important line
 }

--- a/test/controllers/article/ArticleControllerSpec.scala
+++ b/test/controllers/article/ArticleControllerSpec.scala
@@ -12,6 +12,19 @@ import play.api.test._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
+/**
+  * OptionPartial を抑制する理由
+  *
+  * 抑制しない場合「Option#get is disabled - use Option#fold instead」という警告が出る。
+  * プロダクトコードでは確かに、Option 型で get メソッドを使わず、fold メソッドを使うというのは良い習慣に思える。
+  *
+  * 一方で、コントローラのテストでは route(app, FakeRequest(GET, "/any/url")).get というイディオムがよく出てくる。
+  * コントローラのテストでは、fold メソッドなどを使うと逆にテストの見通しが悪くなるように見える。
+  *
+  * よって、コントローラのテストでは明示的に OptionPartial を抑制することにした。
+  * できれば、コントローラのテストだけ OptionPartial を勝手に抑制するようにしたい。
+  */
+@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
 class ArticleControllerSpec extends ControllerSpec {
   "index" when {
     // http://www.innovaedge.com/2015/07/01/how-to-use-mocks-in-injected-objects-with-guiceplayscala/

--- a/test/controllers/article/ArticleControllerSpec.scala
+++ b/test/controllers/article/ArticleControllerSpec.scala
@@ -65,6 +65,8 @@ class ArticleControllerSpec extends ControllerSpec {
         build
     }
 
+    // よく分からんが警告が出る。。
+    @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
     private def articleRepository(articleEntities: Seq[Future[ArticleEntity]]): ArticleRepository = {
       // Mockが返す値を作成
       val articleVector: Future[Seq[ArticleEntity]] = Future.sequence(articleEntities)

--- a/test/fixtures/FixturePath.scala
+++ b/test/fixtures/FixturePath.scala
@@ -1,5 +1,5 @@
 package fixtures
 
 object FixturePath {
-  val HATENA_BOOKMARK_RSS = "/network/hatena_bookmark_rss.xml"
+  val HATENA_BOOKMARK_RSS: String = "/network/hatena_bookmark_rss.xml"
 }

--- a/test/infrastructures/article/ArticleRepositoryImplSpec.scala
+++ b/test/infrastructures/article/ArticleRepositoryImplSpec.scala
@@ -5,6 +5,7 @@ import domains.article.{ArticleEntity, ArticleRepository}
 import org.scalatest.concurrent.ScalaFutures
 import play.api.Application
 
+@SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.Null", "org.wartremover.warts.TraversableOps"))
 class ArticleRepositoryImplSpec extends DatabaseSpec with ScalaFutures {
   def articleRepository(implicit app: Application): ArticleRepository = Application.instanceCache[ArticleRepositoryImpl].apply(app)
 

--- a/test/infrastructures/crawler/HatenaBookmarkParserImplSpec.scala
+++ b/test/infrastructures/crawler/HatenaBookmarkParserImplSpec.scala
@@ -4,8 +4,9 @@ import base.scalatest.utility.FixtureLoader
 import fixtures.FixturePath
 import org.scalatestplus.play.PlaySpec
 
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
 class HatenaBookmarkParserImplSpec extends PlaySpec {
-  val sut = new HatenaBookmarkParserImpl()
+  private val sut = new HatenaBookmarkParserImpl()
 
   "parse" should {
     "success" in {

--- a/test/services/article/ArticleServiceSpec.scala
+++ b/test/services/article/ArticleServiceSpec.scala
@@ -31,6 +31,7 @@ class ArticleServiceSpec extends PlaySpec with MockitoSugar with ScalaFutures {
         build
     }
 
+    @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
     private def articleRepository(): ArticleRepository = {
       // Mockが返す値を作成
       val articleVector: Future[Seq[ArticleEntity]] = Future.sequence(Seq(Future {

--- a/test/services/crawler/HatenaBookmarkServiceSpec.scala
+++ b/test/services/crawler/HatenaBookmarkServiceSpec.scala
@@ -36,6 +36,7 @@ class HatenaBookmarkServiceSpec extends PlaySpec with MockitoSugar {
         build
     }
 
+    @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
     def mockHatenaBookmarkApi(): HatenaBookmarkApi = {
       // Mockが返す値を作成
       val response: Future[String] = Future{ FixtureLoader.load(FixturePath.HATENA_BOOKMARK_RSS) }
@@ -46,6 +47,7 @@ class HatenaBookmarkServiceSpec extends PlaySpec with MockitoSugar {
       hatenaBookmarkApi
     }
 
+    @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
     def mockArticleRepository(): ArticleRepository = {
       // Mockが返す値を作成
       val futureUnit: Future[Unit] = Future[Unit]{}


### PR DESCRIPTION
### Before

```

[warn] /Users/owner/github/scala-ddd/test/ApplicationSpec.scala:23: [wartremover:OptionPartial] Option#get is disabled - use Option#fold instead
[warn]       val home = route(app, FakeRequest(GET, "/")).get
[warn]                                                    ^
[warn] /Users/owner/github/scala-ddd/test/ApplicationSpec.scala:35: [wartremover:OptionPartial] Option#get is disabled - use Option#fold instead
[warn]       contentAsString(route(app, FakeRequest(GET, "/count")).get) mustBe "0"
[warn]                                                              ^
[warn] /Users/owner/github/scala-ddd/test/ApplicationSpec.scala:36: [wartremover:OptionPartial] Option#get is disabled - use Option#fold instead
[warn]       contentAsString(route(app, FakeRequest(GET, "/count")).get) mustBe "1"
[warn]                                                              ^
[warn] /Users/owner/github/scala-ddd/test/ApplicationSpec.scala:37: [wartremover:OptionPartial] Option#get is disabled - use Option#fold instead
[warn]       contentAsString(route(app, FakeRequest(GET, "/count")).get) mustBe "2"
[warn]                                                              ^
[warn] /Users/owner/github/scala-ddd/test/IntegrationSpec.scala:15: [wartremover:StringPlusAny] Implicit conversion to string is disabled
[warn]       go to ("http://localhost:" + port)
[warn]                                  ^
[warn] /Users/owner/github/scala-ddd/test/base/scalatest/DatabaseSpec.scala:62: [wartremover:PublicInference] Public member must have an explicit type ascription
[warn]   lazy val databaseApi = app.injector.instanceOf[DBApi] //here is the important line
[warn]            ^
[warn] /Users/owner/github/scala-ddd/test/controllers/article/ArticleControllerSpec.scala:61: [wartremover:NonUnitStatements] Statements must return Unit
[warn]       when(articleRepository.listAll()).thenReturn(articleVector)
[warn]                                                   ^
[warn] /Users/owner/github/scala-ddd/test/controllers/article/ArticleControllerSpec.scala:23: [wartremover:OptionPartial] Option#get is disabled - use Option#fold instead
[warn]         val json = route(mockApp, FakeRequest(GET, "/articles")).get
[warn]                                                                  ^
[warn] /Users/owner/github/scala-ddd/test/controllers/article/ArticleControllerSpec.scala:35: [wartremover:OptionPartial] Option#get is disabled - use Option#fold instead
[warn]         val json = route(mockApp, FakeRequest(GET, "/articles")).get
[warn]                                                                  ^
[warn] /Users/owner/github/scala-ddd/test/fixtures/FixturePath.scala:4: [wartremover:PublicInference] Public member must have an explicit type ascription
[warn]   val HATENA_BOOKMARK_RSS = "/network/hatena_bookmark_rss.xml"
[warn]       ^
[warn] /Users/owner/github/scala-ddd/test/infrastructures/article/ArticleRepositoryImplSpec.scala:9: [wartremover:ImplicitParameter] Implicit parameters are disabled
[warn]   def articleRepository(implicit app: Application): ArticleRepository = Application.instanceCache[ArticleRepositoryImpl].apply(app)
[warn]       ^
[warn] /Users/owner/github/scala-ddd/test/infrastructures/article/ArticleRepositoryImplSpec.scala:29: [wartremover:Null] null is disabled
[warn]           actual.head.id must not be null // scalastyle:ignore
[warn]                                      ^
[warn] /Users/owner/github/scala-ddd/test/infrastructures/article/ArticleRepositoryImplSpec.scala:29: [wartremover:TraversableOps] head is disabled - use headOption instead
[warn]           actual.head.id must not be null // scalastyle:ignore
[warn]                  ^
[warn] /Users/owner/github/scala-ddd/test/infrastructures/article/ArticleRepositoryImplSpec.scala:30: [wartremover:TraversableOps] head is disabled - use headOption instead
[warn]           actual.head.title mustBe articleEntity.title
[warn]                  ^
[warn] /Users/owner/github/scala-ddd/test/infrastructures/article/ArticleRepositoryImplSpec.scala:31: [wartremover:TraversableOps] head is disabled - use headOption instead
[warn]           actual.head.url mustBe articleEntity.url
[warn]                  ^
[warn] /Users/owner/github/scala-ddd/test/infrastructures/article/ArticleRepositoryImplSpec.scala:39: [wartremover:TraversableOps] head is disabled - use headOption instead
[warn]           actual.head must have (
[warn]                  ^
[warn] /Users/owner/github/scala-ddd/test/infrastructures/crawler/HatenaBookmarkParserImplSpec.scala:8: [wartremover:PublicInference] Public member must have an explicit type ascription
[warn]   val sut = new HatenaBookmarkParserImpl()
[warn]       ^
[warn] /Users/owner/github/scala-ddd/test/infrastructures/crawler/HatenaBookmarkParserImplSpec.scala:16: [wartremover:TraversableOps] head is disabled - use headOption instead
[warn]       actual.head.title mustBe "今年もやっぱり来ちゃったよ！　2017年エイプリルフールまとめ - ねとらぼ"
[warn]              ^
[warn] /Users/owner/github/scala-ddd/test/infrastructures/crawler/HatenaBookmarkParserImplSpec.scala:17: [wartremover:TraversableOps] head is disabled - use headOption instead
[warn]       actual.head.url mustBe "http://nlab.itmedia.co.jp/nl/articles/1704/01/news003.html"
[warn]              ^
[warn] /Users/owner/github/scala-ddd/test/services/article/ArticleServiceSpec.scala:42: [wartremover:NonUnitStatements] Statements must return Unit
[warn]       when(articleRepository.listAll()).thenReturn(articleVector)
[warn]                                                   ^
[warn] /Users/owner/github/scala-ddd/test/services/crawler/HatenaBookmarkServiceSpec.scala:45: [wartremover:NonUnitStatements] Statements must return Unit
[warn]       when(hatenaBookmarkApi.request()).thenReturn(response)
[warn]                                                   ^
[warn] /Users/owner/github/scala-ddd/test/services/crawler/HatenaBookmarkServiceSpec.scala:55: [wartremover:NonUnitStatements] Statements must return Unit
[warn]       when(articleRepository.insert(any[ArticleEntity])).thenReturn(futureUnit)
[warn]                                                                    ^
[warn] 22 warnings found
```

### After

完全に駆逐