### PR TITLE
テスト時のみWartRemoverのOptionPartial警告を除外

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,17 +95,34 @@ testScalastyle := org.scalastyle.sbt.ScalastylePlugin.scalastyle.in(Compile).toT
 (test in Test) <<= (test in Test) dependsOn testScalastyle
 
 /**
-  * WartRemover の設定
+  * WartRemover のプロダクトコード側の設定
   *
   * - 警告の除外設定
-  *   - Overloading : オーバーロードは許可しておかないと、テストのbeforeEachとか怒られるので除外
+  *   - Overloading : オーバーロードは普通に使われるものであるため除外
   * - 警告の除外ファイル
   *   - routes : ルーティング設定は事実上のDSLなのでチェックしない
   *
   * @see http://www.wartremover.org/doc/install-setup.html
   */
-wartremoverErrors ++= Warts.allBut(Wart.Overloading)
+wartremoverErrors in (Compile, compile) ++= Warts.allBut(Wart.Overloading)
 // 本当は右記のように書こうとした => wartremoverExcluded += baseDirectory.value / "conf" / "routes"
 // が、除外してくれなかったので、このような書き方に落ち着いた。たぶん、conf配下のファイルは扱いが特殊なんだろう。
 // http://stackoverflow.com/questions/34788530/wartremover-still-reports-warts-in-excluded-play-routes-file
 wartremoverExcluded ++= routes.in(Compile).value
+
+/**
+  * WartRemover のテストコード側の設定
+  *
+  * - 警告の除外設定
+  *   - Overloading : オーバーロードは許可しておかないと、テストのbeforeEachとか怒られるので除外
+  *   - OptionPartial : コントローラでよく出てくるイディオム route(app, FakeRequest(GET, "/any/url")).get が引っかかるため除外
+  *
+  * - OptionPartial を抑制する詳細な理由
+  *   - 抑制しない場合、コントローラのテストなどで「Option#get is disabled - use Option#fold instead」という警告が出る。
+  *   - プロダクトコードでは確かに、Option 型で get メソッドを使わず、fold メソッドを使うというのは良い習慣に思える。
+  *   - 一方で、コントローラのテストでは route(app, FakeRequest(GET, "/any/url")).get というイディオムがよく出てくる。
+  *   - コントローラのテストでは、fold メソッドなどを使うと逆にテストの見通しが悪くなるように見える。
+  *   - よって、テストコードでは OptionPartial を抑制することにした。
+  *   - 本当はコントローラのテストコードだけ指定とかできればよいが、そこは妥協することとした。
+  */
+wartremoverErrors in (Test, test) ++= Warts.allBut(Wart.Overloading, Wart.OptionPartial)

--- a/test/ApplicationSpec.scala
+++ b/test/ApplicationSpec.scala
@@ -7,7 +7,6 @@ import play.api.test.Helpers._
  * You can mock out a whole application including requests, plugins etc.
  * For more information, consult the wiki.
  */
-@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
 class ApplicationSpec extends PlaySpec with OneAppPerTest {
 
   "Routes" should {

--- a/test/controllers/article/ArticleControllerSpec.scala
+++ b/test/controllers/article/ArticleControllerSpec.scala
@@ -12,19 +12,6 @@ import play.api.test._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-/**
-  * OptionPartial を抑制する理由
-  *
-  * 抑制しない場合「Option#get is disabled - use Option#fold instead」という警告が出る。
-  * プロダクトコードでは確かに、Option 型で get メソッドを使わず、fold メソッドを使うというのは良い習慣に思える。
-  *
-  * 一方で、コントローラのテストでは route(app, FakeRequest(GET, "/any/url")).get というイディオムがよく出てくる。
-  * コントローラのテストでは、fold メソッドなどを使うと逆にテストの見通しが悪くなるように見える。
-  *
-  * よって、コントローラのテストでは明示的に OptionPartial を抑制することにした。
-  * できれば、コントローラのテストだけ OptionPartial を勝手に抑制するようにしたい。
-  */
-@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
 class ArticleControllerSpec extends ControllerSpec {
   "index" when {
     // http://www.innovaedge.com/2015/07/01/how-to-use-mocks-in-injected-objects-with-guiceplayscala/


### PR DESCRIPTION
テストコードで OptionPartial を抑制する理由。

抑制しない場合、コントローラのテストなどで「Option#get is disabled - use Option#fold instead」という警告が出る。プロダクトコードでは確かに、Option 型で get メソッドを使わず、fold メソッドを使うというのは良い習慣に思える。

一方で、コントローラのテストでは route(app, FakeRequest(GET, "/any/url")).get というイディオムがよく出てくる。コントローラのテストでは、fold メソッドなどを使うと逆にテストの見通しが悪くなるように見える。

よって、テストコードでは OptionPartial を抑制することにした。本当はコントローラのテストコードだけ指定とかできればよいが、そこは妥協することとした。