### PR TITLE
リクエスト単位でRequestIdを生成するRequestHandlerを作成

### DIFF
--- a/app/cores/request/RequestId.scala
+++ b/app/cores/request/RequestId.scala
@@ -1,0 +1,30 @@
+package cores.request
+
+import java.util.UUID
+
+/**
+  * リクエストID
+  *
+  * HTTPリクエストされるたびに、ユニークなIDを払い出す。
+  * ログのトラーサビリティ向上が目的。
+  */
+private[cores] sealed trait RequestId {
+  def value: String
+}
+
+/**
+  * リクエストIDのコンパニオンクラス
+  */
+private[cores] object RequestId {
+  /**
+    * リクエストIDの初期化
+    *
+    * @return リクエストID
+    */
+  def initialize(): RequestId = {
+    val value = UUID.randomUUID().toString
+    RequestIdImpl(value)
+  }
+}
+
+private final case class RequestIdImpl(value: String) extends RequestId

--- a/app/cores/request_handler/RequestHandler.scala
+++ b/app/cores/request_handler/RequestHandler.scala
@@ -1,0 +1,49 @@
+package cores.request_handler
+
+import javax.inject.{Inject, Singleton}
+
+import cores.request_handler.internal.RequestInitializer
+import play.api.http.{DefaultHttpRequestHandler, HttpConfiguration, HttpErrorHandler, HttpFilters}
+import play.api.mvc.{Handler, RequestHeader}
+import play.api.routing.Router
+
+/**
+  * リクエストハンドラー
+  *
+  * HTTPリクエストされると呼び出される。
+  * RequestHeader オブジェクトにタグをセットするために、本リクエストハンドラーを実装している。
+  *
+  * ドキュメントにも記載がある通り、リクエスト時の共通処理は、
+  * 可能な限り Router や Filter で行うべきであり、本クラスを拡張するのは最終手段とすること。
+  *
+  * 本クラスで実現している処理は当初 Filter で実装を試みたが、
+  * RequestHeader オブジェクトへのタグのセットができなかったため、やむなく独自のリクエストハンドラーを定義した。
+  * もしかすると Filter の実装方法が間違っていただけかもしれず、その場合は、本クラスの処理は Filter へ移動可能である。
+  *
+  * 本リクエストハンドラーを使用するようアプリケーションに組み込むには、明示的に設定ファイルへの記述が必要。
+  * 多くの場合 conf/application.conf ファイルに記述することになる。
+  * 設定箇所は play.http の requestHandler の項目である。
+  *
+  * @see https://www.playframework.com/documentation/2.5.x/ScalaHttpRequestHandlers#Extending-the-default-request-handler
+  * @param router        A router.
+  * @param errorHandler  Component for handling HTTP errors in Play
+  * @param configuration HTTP related configuration of a Play application
+  * @param filters       Provides filters to the [[play.api.http.HttpRequestHandler]]
+  */
+@Singleton
+final class RequestHandler @Inject()(router: Router,
+                                     errorHandler: HttpErrorHandler,
+                                     configuration: HttpConfiguration,
+                                     filters: HttpFilters
+                                    ) extends DefaultHttpRequestHandler(router, errorHandler, configuration, filters) {
+
+  /**
+    * リクエストの処理を開始する前に、リクエストヘッダーにタグをセットする
+    *
+    * @param request The request to handle
+    * @return The possibly modified/tagged request, and a handler to handle it
+    */
+  override def handlerForRequest(request: RequestHeader): (RequestHeader, Handler) = {
+    super.handlerForRequest(RequestInitializer.initialize(request))
+  }
+}

--- a/app/cores/request_handler/internal/RequestInitializer.scala
+++ b/app/cores/request_handler/internal/RequestInitializer.scala
@@ -1,0 +1,30 @@
+package cores.request_handler.internal
+
+import cores.request.RequestId
+import play.api.mvc.RequestHeader
+
+/**
+  * RequestHeader オブジェクトにタグ情報を追加して初期化するクラス
+  */
+private[request_handler] object RequestInitializer {
+  /**
+    * リクエストヘッダーにタグを追加して初期化
+    *
+    * @param requestHeader リクエストヘッダー
+    * @return タグ追加済みのリクエストヘッダー
+    */
+  def initialize(requestHeader: RequestHeader): RequestHeader = {
+    val requestId = RequestId.initialize()
+    requestHeader.withTag(RequestHeaderTagName.RequestId, requestId.value)
+  }
+}
+
+/**
+  * リクエストヘッダーのタグ名を定数定義するクラス
+  *
+  * タグ名が大文字のスネークケースな理由は、同じくタグ名を定義している
+  * [[play.api.routing.Router.Tags]] がそうなっているからである。
+  */
+private[internal] object RequestHeaderTagName {
+  val RequestId: String = "REQUEST_ID"
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -135,6 +135,16 @@ play.http {
   # ここの設定を書き換えると、変更することが可能である。
   errorHandler = cores.error_handler.ErrorHandler
 
+  # リクエストハンドラーの設定
+  #
+  # app/RequestHandler.scalaが存在すれば、設定なしで読み込まれるが
+  # 置き場を変更しているため、明示的に設定を行っている。
+  #
+  # リクエストIDなど、Servletで言うリクエストスコープのオブジェクトの生成を行うことを想定している。
+  #
+  # https://www.playframework.com/documentation/2.5.x/ScalaHttpRequestHandlers#Configuring-the-http-request-handler
+  requestHandler = cores.request_handler.RequestHandler
+
   ## Filters
   # https://www.playframework.com/documentation/latest/ScalaHttpFilters
   # https://www.playframework.com/documentation/latest/JavaHttpFilters

--- a/test/cores/request/RequestIdSpec.scala
+++ b/test/cores/request/RequestIdSpec.scala
@@ -1,0 +1,12 @@
+package cores.request
+
+import org.scalatestplus.play.PlaySpec
+
+class RequestIdSpec extends PlaySpec {
+  "RequestId#initialize" should {
+    "リクエストIDが生成できること" in {
+      val actual = RequestId.initialize()
+      actual.value.length mustBe 36
+    }
+  }
+}

--- a/test/cores/request_handler/internal/RequestInitializerSpec.scala
+++ b/test/cores/request_handler/internal/RequestInitializerSpec.scala
@@ -1,0 +1,13 @@
+package cores.request_handler.internal
+
+import org.scalatestplus.play.PlaySpec
+import play.api.test.FakeRequest
+
+class RequestInitializerSpec extends PlaySpec {
+  "RequestInitializer#initialize" should {
+    "リクエストヘッダーにタグがセットされていること" in {
+      val actual = RequestInitializer.initialize(FakeRequest())
+      actual.tags(RequestHeaderTagName.RequestId).length mustBe 36
+    }
+  }
+}


### PR DESCRIPTION
リクエストごとに、ユニークな識別子を発行して、ログ出力時にgrepしやすいようにしたい。

そこで、Servletでいうリクエストスコープオブジェクトを`HttpRequestHandler`を使って実装する。
具体的には、`HttpRequestHandler`内で`RequestHeader`オブジェクトの内容を書き換える（タグをセットする）ことにより、実現した。

これにより、`RequestHeader`にアクセスできるクラスからは自由に、同一リクエスト内でのみ有効なデータを扱うことができる。

些末な話だが、RequestIdクラスの実装は、[リラクのサーバサイド事情 with Scala / ドメイン編](http://techblog.reraku.co.jp/entry/2016/12/08/080000)を参考にしている。

* 参考
  * [リクエストスコープについて](http://www.javaroad.jp/servletjsp/sj_servlet4.htm)
  * [Play2(Scala)でMDCを使う](http://qiita.com/castersupermild/items/b5682828307430e2cc9a)