### PR TITLE
Revert "Taskが正常終了しない問題を解消"

### DIFF
--- a/app/cores/task/Task.scala
+++ b/app/cores/task/Task.scala
@@ -2,8 +2,6 @@ package cores.task
 
 import cores.task.internal.{ApplicationInjector, Execution, ExecutionStart}
 
-import scala.util.control.Exception.{Catch, ultimately}
-
 /**
   * コマンドラインから実行可能なアプリケーション
   *
@@ -11,22 +9,5 @@ import scala.util.control.Exception.{Catch, ultimately}
   * 本クラスを extends したクラスを実装する。
   */
 trait Task extends App with Execution with ApplicationInjector {
-  withExit {
-    ExecutionStart.start(this)
-  }
-
-  /**
-    * JVM の終了
-    *
-    * 終了処理を書かないとタスクが正常終了してくれない。（プロセスが刺さった状態になる）
-    * 毎回 Ctrl + C を押すのは不便すぎるので、明示的に JVM を終了させることにした。
-    * ただし、この実装だと、例外発生時も exit code が 0 になってしまうことに注意。
-    *
-    * @see http://stackoverflow.com/questions/21464673/sbt-trapexitsecurityexception-thrown-at-sbt-run
-    */
-  private def withExit: Catch[Unit] = {
-    ultimately[Unit] {
-      sys.exit()
-    }
-  }
+  ExecutionStart.start(this)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -27,15 +27,6 @@ resourceDirectory in Test := baseDirectory.value / "test/resources"
 // テスト時に読み込むlogbackの設定を切り替え
 javaOptions in Test += "-Dlogger.resource=logback-test.xml"
 
-/**
-  * fork して実行するよう設定
-  *
-  * これを書かないと Task 実行時に正常終了してくれない。
-  *
-  * @see http://stackoverflow.com/questions/21464673/sbt-trapexitsecurityexception-thrown-at-sbt-run
-  */
-fork in run := true
-
 // 依存ライブラリ
 // 定期的にバージョンアップしたい
 libraryDependencies ++= Seq(


### PR DESCRIPTION
テストがおかしな終了をするようになった。しかも正常終了で気づかなかったorz

```
[info] ExecutionStartSpec:
[info] ExecutionStart#start
Exception in thread "Thread-2" Exception in thread "Thread-6" java.io.EOFException
	at java.io.ObjectInputStream$BlockDataInputStream.peekByte(ObjectInputStream.java:2903)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1502)
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:422)
	at org.scalatest.tools.Framework$ScalaTestRunner$Skeleton$1$React.react(Framework.scala:809)
	at org.scalatest.tools.Framework$ScalaTestRunner$Skeleton$1.run(Framework.scala:798)
	at java.lang.Thread.run(Thread.java:745)
java.net.SocketException: Connection reset
	at java.net.SocketInputStream.read(SocketInputStream.java:210)
	at java.net.SocketInputStream.read(SocketInputStream.java:141)
	at java.net.SocketInputStream.read(SocketInputStream.java:224)
	at java.io.ObjectInputStream$PeekInputStream.peek(ObjectInputStream.java:2584)
	at java.io.ObjectInputStream$BlockDataInputStream.peek(ObjectInputStream.java:2891)
	at java.io.ObjectInputStream$BlockDataInputStream.peekByte(ObjectInputStream.java:2901)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1502)
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:422)
	at sbt.React.react(ForkTests.scala:114)
	at sbt.ForkTests$$anonfun$mainTestTask$1$Acceptor$2$.run(ForkTests.scala:74)
	at java.lang.Thread.run(Thread.java:745)
[info] ScalaTest
```