### PR TITLE
Scapegoatのバージョンを指定

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ libraryDependencies ++= Seq(
   //   Loading class `com.mysql.jdbc.Driver'. This is deprecated. The new driver class is `com.mysql.cj.jdbc.Driver'. The driver is automatically registered via the SPI and manual loading of the driver class is generally unnecessary.
   //   [warn] c.z.h.u.DriverDataSource - Registered driver with driverClassName=com.mysql.jdbc.Driver was not found, trying direct instantiation.
   // scalastyle:on
-  "mysql" % "mysql-connector-java" % "5.1.41",
+  "mysql" % "mysql-connector-java" % "5.1.42",
   // O/Rマッパー
   // http://skinny-framework.org/documentation/orm.html
   "org.skinny-framework" %% "skinny-orm" % "2.3.6",

--- a/build.sbt
+++ b/build.sbt
@@ -126,7 +126,7 @@ libraryDependencies ++= Seq(
   // Twitter API Client
   // Java で最もメジャーなライブラリっぽい
   // https://github.com/yusuke/twitter4j
-  "org.twitter4j" % "twitter4j-core" % "4.0.4",
+  "org.twitter4j" % "twitter4j-core" % "4.0.6",
 
   // ちゃんと調べてないけど、こっから下はテスト用だと思われる
   //

--- a/build.sbt
+++ b/build.sbt
@@ -259,6 +259,11 @@ wartremoverExcluded ++= routes.in(Compile).value
 wartremoverErrors in(Test, test) ++= Warts.allBut(Wart.Overloading, Wart.OptionPartial)
 
 /**
+  * Scapegoat のバージョンを指定
+  */
+scapegoatVersion := "1.3.0"
+
+/**
   * Scapegoat で除外する対象
   */
 scapegoatIgnoredFiles := Seq(

--- a/test/infrastructures/tweet/TweetApiImplSpec.scala
+++ b/test/infrastructures/tweet/TweetApiImplSpec.scala
@@ -53,6 +53,10 @@ class TweetApiImplSpec extends PlaySpec with MockitoSugar {
 
     def getText: String = ""
 
+    def getDisplayTextRangeStart: Int = 0
+
+    def getDisplayTextRangeEnd: Int = 0
+
     def getSource: String = ""
 
     def isTruncated: Boolean = true
@@ -122,6 +126,8 @@ class TweetApiImplSpec extends PlaySpec with MockitoSugar {
     def getId: Long = 0
 
     def getName: String = ""
+
+    def getEmail: String = ""
 
     def getScreenName: String = ""
 


### PR DESCRIPTION
* before

```
[info] Found 5 dependency updates for scala-ddd
[info]   com.sksamuel.scapegoat:scalac-scapegoat-plugin_2.11:compile : 1.0.0            -> 1.3.0
[info]   com.typesafe.play:twirl-api                                 : 1.1.1            -> 1.3.0
[info]   mysql:mysql-connector-java                                  : 5.1.41 -> 5.1.42          -> 6.0.6
[info]   net.sourceforge.pmd:pmd-dist:cpd->default                   : 5.4.2  -> 5.4.6  -> 5.6.1
[info]   org.twitter4j:twitter4j-core                                : 4.0.4  -> 4.0.6
```

* after

```
[info] Found 3 dependency updates for scala-ddd
[info]   com.typesafe.play:twirl-api               : 1.1.1           -> 1.3.0
[info]   mysql:mysql-connector-java                : 5.1.42                   -> 6.0.6
[info]   net.sourceforge.pmd:pmd-dist:cpd->default : 5.4.2  -> 5.4.6 -> 5.6.1
```