### PR TITLE
依存ライブラリをバージョンアップ

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,7 @@ libraryDependencies ++= Seq(
   "mysql" % "mysql-connector-java" % "5.1.42",
   // O/Rマッパー
   // http://skinny-framework.org/documentation/orm.html
-  "org.skinny-framework" %% "skinny-orm" % "2.3.6",
+  "org.skinny-framework" %% "skinny-orm" % "2.3.7",
   // コネクションプールの作成に必要
   //
   // Skinny-ORM は内部的に ScalikeJDBC を使っており、コネクションプールを初期化する必要がある

--- a/build.sbt
+++ b/build.sbt
@@ -131,7 +131,7 @@ libraryDependencies ++= Seq(
   //
   // モック用ライブラリ
   // DBアクセスやネットワークアクセスを差し替えたい時に使う
-  "org.mockito" % "mockito-core" % "2.7.22" % Test,
+  "org.mockito" % "mockito-core" % "2.8.9" % Test,
   // xUnit用ライブラリ
   // playの標準テストライブラリなので、そのまま採用する
   "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.0" % Test

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.14")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.15")
 
 // JS/CSS絡みは無効にしておく
 // どうせREST APIしか実装しないのでこの記述は不要


### PR DESCRIPTION
### before

```
[info] Found 14 dependency updates for scala-ddd
[info]   com.typesafe.play:play-cache              : 2.5.14 -> 2.5.15
[info]   com.typesafe.play:play-jdbc               : 2.5.14 -> 2.5.15
[info]   com.typesafe.play:play-jdbc-evolutions    : 2.5.14 -> 2.5.15
[info]   com.typesafe.play:play-logback            : 2.5.14 -> 2.5.15
[info]   com.typesafe.play:play-netty-server       : 2.5.14 -> 2.5.15
[info]   com.typesafe.play:play-omnidoc:docs       : 2.5.14 -> 2.5.15
[info]   com.typesafe.play:play-server             : 2.5.14 -> 2.5.15
[info]   com.typesafe.play:play-test:test          : 2.5.14 -> 2.5.15
[info]   com.typesafe.play:play-ws                 : 2.5.14 -> 2.5.15
[info]   com.typesafe.play:twirl-api               : 1.1.1            -> 1.3.0
[info]   mysql:mysql-connector-java                : 5.1.42                    -> 6.0.6
[info]   net.sourceforge.pmd:pmd-dist:cpd->default : 5.4.2  -> 5.4.6  -> 5.7.0
[info]   org.mockito:mockito-core:test             : 2.7.22           -> 2.8.9
[info]   org.skinny-framework:skinny-orm           : 2.3.6  -> 2.3.7
```

### after

```
[info]   com.typesafe.play:twirl-api               : 1.1.1           -> 1.3.0
[info]   mysql:mysql-connector-java                : 5.1.42                   -> 6.0.6
[info]   net.sourceforge.pmd:pmd-dist:cpd->default : 5.4.2  -> 5.4.6 -> 5.7.0
```